### PR TITLE
GICv2 Distributor Config Cache

### DIFF
--- a/include/arch/arm/arch/machine/gic_v2.h
+++ b/include/arch/arm/arch/machine/gic_v2.h
@@ -22,6 +22,7 @@
 
 #define IRQ_MASK MASK(10u)
 #define GIC_VCPU_MAX_NUM_LR 64
+#define GIC_DIST_CONFIG_SIZE 64
 
 /* Helpers for VGIC */
 #define VGIC_HCR_EOI_INVALID_COUNT(hcr) (((hcr) >> 27) & 0x1f)
@@ -124,13 +125,14 @@ struct gic_cpu_iface_map {
 
 extern volatile struct gic_dist_map *const gic_dist;
 extern volatile struct gic_cpu_iface_map *const gic_cpuiface;
+extern uint32_t gic_dist_config_cache[GIC_DIST_CONFIG_SIZE];
 
 /* Helpers */
 static inline int is_irq_edge_triggered(word_t irq)
 {
     int word = irq >> 4;
     int bit = ((irq & 0xf) * 2);
-    return !!(gic_dist->config[word] & BIT(bit + 1));
+    return !!(gic_dist_config_cache[word] & BIT(bit + 1));
 }
 
 static inline void dist_pending_clr(word_t irq)

--- a/src/arch/arm/machine/gic_v2.c
+++ b/src/arch/arm/machine/gic_v2.c
@@ -25,6 +25,7 @@
 #else  /* GIC_DISTRIBUTOR_PPTR */
 volatile struct gic_dist_map *const gic_dist =
     (volatile struct gic_dist_map *)(GIC_V2_DISTRIBUTOR_PPTR);
+uint32_t gic_dist_config_cache[GIC_DIST_CONFIG_SIZE];
 #endif /* GIC_DISTRIBUTOR_PPTR */
 
 #ifndef GIC_V2_CONTROLLER_PPTR
@@ -95,6 +96,10 @@ BOOT_CODE static void dist_init(void)
         gic_dist->config[i >> 5] = 0x55555555;
     }
 
+    for (i = 0; i < GIC_DIST_CONFIG_SIZE; i++) {
+        gic_dist_config_cache[i] = gic_dist->config[i];
+    }
+
     /* group 0 for secure; group 1 for non-secure */
     for (i = 0; i < nirqs; i += 32) {
         if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT) && !config_set(CONFIG_PLAT_QEMU_ARM_VIRT)) {
@@ -157,8 +162,10 @@ void setIRQTrigger(irq_t irq, bool_t trigger)
     if (trigger) {
         /* set the bit */
         gic_dist->config[index] |= BIT(offset + 1);
+        gic_dist_config_cache[index] |= BIT(offset + 1);
     } else {
         gic_dist->config[index] &= ~BIT(offset + 1);
+        gic_dist_config_cache[index] &= ~BIT(offset + 1);
     }
 }
 


### PR DESCRIPTION
Every time an IRQ occurs the kernel reads from a GICv2 distributor configuration register to determine whether the interrupt is edge-triggered or level-triggered. If it is edge-triggered, the pending status of the interrupt must be cleared. This read from the distributor was observed to be expensive and so this pull request implements a cache for the interrupt configuration registers.

The following seL4Bench benchmarks demonstrate the performance improvement of this change using unicore MCS as measured from userspace:

| Platform | cycles before: mean (stddev) | cycles after: mean (stddev) | diff: absolute (%) |
|---|---|---|---|
| OdroidC2 | 1132 (7) | 916 (7) | 216 (19%) |
| OdroidC4 | 1111 (7) | 836 (6) | 275 (25%) |
| TX1 | 1019 (7) | 817 (8) | 202 (20%) |
