### PR TITLE
VM fault fastpath: missing rename of vspace cap ASID function

### DIFF
--- a/manual/parts/vspace.tex
+++ b/manual/parts/vspace.tex
@@ -109,23 +109,19 @@ configurations.
 \subsubsection{AArch64}
 
 Depending on configuration, Arm AArch64 processors have page-table structures with 3 or 4 levels.
-The VSpace object is therefore implemented either by the \obj{PageGlobalDirectory} object (4 level
-configs) or the \obj{PageUpperDirectory} object (3 level configs). To help with writing code that is
-generic in this distinction, \texttt{libsel4} provides the macro \texttt{seL4\_ARM\_VSpaceObject}
-that expands to the correct corresponding object. All intermediate paging structures are indexed by
-9 bits of the virtual address. Depending on configuration, the top-level object is indexed by either
-9 or 10 bits. The macro \texttt{seL4\_VSpaceIndexBits} makes this value available under a generic
-name. The table below shows the four-level configuration. On three-level configurations, the
-invocations for \texttt{seL4\_ARM\_VSpaceObject} capabilities are instead available on
-\obj{PageUpperDirectory} caps.
+The VSpace object is \texttt{seL4\_ARM\_VSpaceObject}, which is a distinct object type used for the
+top level page table. All intermediate paging structures are indexed by 9 bits of the virtual
+address and are \obj{PageTable} objects. Depending on configuration, the top-level object is
+indexed by either 9 or 10 bits. The macro \texttt{seL4\_VSpaceIndexBits} makes this value available
+under a generic name. The table below shows the four-level configuration.
 
 \begin{tabularx}{\textwidth}{Xlll} \toprule
 \emph{Object}                    & \emph{Address Bits} & \emph{Level} & \emph{Methods} \\ \midrule
-    \texttt{PageGlobalDirectory}/\texttt{seL4\_ARM\_VSpaceObject}
+    \texttt{seL4\_ARM\_VSpaceObject}
                                  & 39---47             & 0            & \autoref{group__aarch64__seL4__ARM__VSpace} \\
-    \texttt{PageUpperDirectory}  & 30---38             & 1            & \autoref{group__aarch64__seL4__ARM__PageUpperDirectory} \\
-\texttt{PageDirectory}           & 21---29             & 2            & \autoref{group__aarch64__seL4__ARM__PageDirectory} \\
-\texttt{PageTable}               & 12---20             & 3            & \autoref{group__arm__seL4__ARM__PageTable} \\
+    \texttt{PageTable}           & 30---38             & 1            & \autoref{group__arm__seL4__ARM__PageTable} \\
+    \texttt{PageTable}           & 21---29             & 2            & \autoref{group__arm__seL4__ARM__PageTable} \\
+    \texttt{PageTable}           & 12---20             & 3            & \autoref{group__arm__seL4__ARM__PageTable} \\
 \bottomrule
 \end{tabularx}
 

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -779,7 +779,7 @@ void NORETURN fastpath_vm_fault(vm_fault_type_t type)
 
 #ifdef CONFIG_ARCH_AARCH64
     /* Need to test that the ASID is still valid */
-    asid_t asid = cap_vtable_root_get_mappedASID(newVTable);
+    asid_t asid = cap_vspace_cap_get_capMappedASID(newVTable);
     asid_map_t asid_map = findMapForASID(asid);
     if (unlikely(asid_map_get_type(asid_map) != asid_map_asid_map_vspace ||
                  VSPACE_PTR(asid_map_asid_map_vspace_get_vspace_root(asid_map)) != cap_pd)) {


### PR DESCRIPTION
This change was missing from commit dc808b3d76fc09741e91ccc53e2738d052c08f0a. Renames `cap_vtable_root_get_mappedASID` to `cap_vspace_cap_get_capMappedASID`, allowing builds with the exception fastpath enabled to build.