### PR TITLE
aarch64/trivial: update outdated page table macros

### DIFF
--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1918,7 +1918,7 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
 
     ksUserLogBuffer = pptr_to_paddr((void *) frame_pptr);
 
-    *armKSGlobalLogPDE = pde_pde_large_new(
+    *armKSGlobalLogPDE = pte_pte_page_new(
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
                              0, // XN
 #else

--- a/src/arch/arm/64/model/statedata.c
+++ b/src/arch/arm/64/model/statedata.c
@@ -92,9 +92,9 @@ pte_t armKSGlobalKernelPT[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits))
 #ifdef CONFIG_KERNEL_LOG_BUFFER
 pte_t *armKSGlobalLogPDE = &armKSGlobalKernelPDs[BIT(PT_INDEX_BITS) - 1][BIT(PT_INDEX_BITS) - 2];
 compile_assert(log_pude_is_correct_preallocated_pude,
-               GET_PUD_INDEX(KS_LOG_PPTR) == BIT(PT_INDEX_BITS) - 1);
+               GET_KPT_INDEX(KS_LOG_PPTR, KLVL_FRM_ARM_PT_LVL(1)) == BIT(PT_INDEX_BITS) - 1);
 compile_assert(log_pde_is_correct_preallocated_pde,
-               GET_PD_INDEX(KS_LOG_PPTR) == BIT(PT_INDEX_BITS) - 2);
+               GET_KPT_INDEX(KS_LOG_PPTR, KLVL_FRM_ARM_PT_LVL(2)) == BIT(PT_INDEX_BITS) - 2);
 #endif
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT


### PR DESCRIPTION
Update outdated page table index macros and new page functions for aarch64 builds with CONFIG_KERNEL_LOG_BUFFER enabled.